### PR TITLE
Remove sort on change-weigth before put elements in a set

### DIFF
--- a/src/specter_edn/core.clj
+++ b/src/specter_edn/core.clj
@@ -30,11 +30,9 @@
     (and (n/inner? node) (coll? sexpr))
     (let [A (->> (n/child-sexprs node)
               flatten
-              sort
               (into #{}))
           B (->> sexpr
               flatten
-              sort
               (into #{}))]
       (- 1.0 (jaccard-index A B)))
 

--- a/test/specter_edn/core_test.clj
+++ b/test/specter_edn/core_test.clj
@@ -20,4 +20,25 @@
       "42; hi!\n6" [SEXPRS LAST]        9              "42; hi!\n9"
       "42; hi!\n6" [SEXPRS FIRST]       7              "7; hi!\n6"
       "[1]"        [SEXPRS]             '[(1)]         "(1)"
-      "#(conj %)"  [SEXPRS FIRST LAST]  '(dissoc %)    "#(dissoc %)")))
+      "#(conj %)"  [SEXPRS FIRST LAST]  '(dissoc %)    "#(dissoc %)"))
+
+  (testing "can transform inside stringified s-expressions"
+    (are [structure path f result] (= (transform path f structure)
+                                                result)
+      "[1]"        [SEXPRS FIRST FIRST] identity       "[1]"
+      "[1] [3]"    [SEXPRS ALL FIRST]   identity       "[1] [3]"
+      "42; hi!\n6" [SEXPRS LAST]        identity       "42; hi!\n6"
+      "42; hi!\n6" [SEXPRS FIRST]       identity       "42; hi!\n6"
+      "[1]"        [SEXPRS]             identity       "[1]"
+      "(ns specter-edn.core-test
+  (:require [clojure.test :refer :all]
+            [com.rpl.specter :refer :all]
+            [specter-edn.core :refer :all]))"
+                   [SEXPRS]             identity "(ns specter-edn.core-test
+  (:require [clojure.test :refer :all]
+            [com.rpl.specter :refer :all]
+            [specter-edn.core :refer :all]))"
+      ;; FIXME: this sample doesn't pass
+      ; "#(conj %)"  [SEXPRS]             identity       "#(conj %)"
+      )))
+


### PR DESCRIPTION
When trying to work with namespaces I was getting an exception because `change-weight` was calling sort on the elements of a form that contained both `symbols` and `keywords` which are not comparable. Since the next call is adding the elements to a set I removed the sort. The namespace transform test fails prior to the sort removal.

The transform with `identity` doesn't currently work for anonymous functions and I'm not sure about how to make that work but it's not related to the sort problem. I left a commented test but maybe that should be an issue.