### PR TITLE
Whitespace bug

### DIFF
--- a/test/specter_edn/core_test.clj
+++ b/test/specter_edn/core_test.clj
@@ -33,6 +33,13 @@
   (:require [clojure.test :refer :all]
             [com.rpl.specter :refer :all]
             [specter-edn.core :refer :all]))"
-                   [SEXPRS])))
-      ;; FIXME: this sample doesn't pass
-      ;"#(conj %)"  [SEXPRS])))
+                   [SEXPRS]))
+    ;; FIXME: this sample doesn't pass
+    ;"#(conj %)"  [SEXPRS])))
+
+  (testing "constantly transforms preserve of the new structure"
+      (are [structure path result] (= result (transform path (constantly '[a b c d]) structure))
+        "[1]"        [SEXPRS FIRST FIRST] "[[a b c d]]"
+        "[1]"        [SEXPRS] "a b c d"
+        "[1] [3]"    [SEXPRS ALL FIRST] "[[a b c d]] [[a b c d]]")))
+


### PR DESCRIPTION
When a sequence of tokens were added the precondition on `tree-update` was failing. After removing it there was no whitespace being added between them causing `a b` being transformed in `ab`. I added a test case and updated the tree update to add whitespace bettween tokens.